### PR TITLE
Add libzip + php zip extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,13 @@ LABEL repository="https://github.com/chindit/actions-phpunit-symfony"
 LABEL homepage="https://github.com/chindit/actions-phpunit-symfony"
 LABEL maintainer="David Lumaye <littletiger58@gmail.com>"
 
+RUN apt-get update \
+&& apt-get install -y \
+	libzip-dev \
+	zip \
+	unzip \
+&& docker-php-ext-install zip
+
 COPY "entrypoint.sh" "/entrypoint.sh"
 
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
Composer wants to use zip / unzip as a default to install packages.
The zip extension is not part of the php base image so I added it. 